### PR TITLE
extraneous sort in print_query

### DIFF
--- a/py/candle_db
+++ b/py/candle_db
@@ -130,7 +130,6 @@ def print_result(result):
 
 def print_table(D):
     K = D.keys()
-    K.sort()
     n = max(map(len, K)) # Length of longest key
     for (k,v) in D.iteritems():
         print("%*s = %s" % (-n, k, v))


### PR DESCRIPTION
Alternatively, print in sorted order, e.g.

def print_table(D):
    K = D.keys()
    K.sort()
    n = max(map(len, K)) # Length of longest key
    for k in K:
        print("%*s = %s" % (-n, k, D[k]))